### PR TITLE
fix: 헤더 배경 추가

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -4,7 +4,7 @@ import Icon from './Icons';
 
 const Header = () => {
   return (
-    <div className="fixed navbar border-b border-grey md:shadow-md md:border-none justify-center">
+    <div className="fixed bg-base-100 navbar border-b border-grey md:shadow-md md:border-none justify-center">
       <div className="max-w-3xl justify-center w-full">
         <div className="navbar-start flex">
           <Link

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -10,7 +10,6 @@ interface LayoutProps {
 }
 
 const Layout = ({ children, hideBottomBar, hideHeader }: LayoutProps) => {
-  console.log(!hideHeader && !hideBottomBar, !hideBottomBar, !hideHeader);
   return (
     <>
       {!hideHeader && <Header />}

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,4 +1,4 @@
-import cls from '@/utils/classnames';
+import classNames from '@/utils/classnames';
 
 import BottomBar from './BottomBar';
 import Header from './Header';
@@ -14,7 +14,7 @@ const Layout = ({ children, hideBottomBar, hideHeader }: LayoutProps) => {
     <>
       {!hideHeader && <Header />}
       <div
-        className={cls(
+        className={classNames(
           !hideHeader && !hideBottomBar ? 'py-16' : 'py-0',
           !hideBottomBar ? 'pb-16 md:pb-0' : 'pb-0',
           !hideHeader ? 'pt-16' : 'pt-0',

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,0 +1,32 @@
+import cls from '@/utils/classnames';
+
+import BottomBar from './BottomBar';
+import Header from './Header';
+
+interface LayoutProps {
+  children: React.ReactNode;
+  hideHeader?: boolean;
+  hideBottomBar?: boolean;
+}
+
+const Layout = ({ children, hideBottomBar, hideHeader }: LayoutProps) => {
+  console.log(!hideHeader && !hideBottomBar, !hideBottomBar, !hideHeader);
+  return (
+    <>
+      {!hideHeader && <Header />}
+      <div
+        className={cls(
+          !hideHeader && !hideBottomBar ? 'py-16' : 'py-0',
+          !hideBottomBar ? 'pb-16 md:pb-0' : 'pb-0',
+          !hideHeader ? 'pt-16' : 'pt-0',
+          'max-w-3xl mx-auto'
+        )}
+      >
+        {children}
+      </div>
+      {!hideBottomBar && <BottomBar />}
+    </>
+  );
+};
+
+export default Layout;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,7 +10,9 @@ function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <Header />
-      <Component {...pageProps} />
+      <div className="py-16 md:py-0 md:pt-16 max-w-3xl mx-auto">
+        <Component {...pageProps} />
+      </div>
       <BottomBar />
     </>
   );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,21 +1,11 @@
 import '@/styles/globals.css';
-import BottomBar from '@/components/common/BottomBar';
-import Header from '@/components/common/Header';
 
 import { wrapper } from '../store';
 
 import type { AppProps } from 'next/app';
 
 function App({ Component, pageProps }: AppProps) {
-  return (
-    <>
-      <Header />
-      <div className="py-16 md:py-0 md:pt-16 max-w-3xl mx-auto">
-        <Component {...pageProps} />
-      </div>
-      <BottomBar />
-    </>
-  );
+  return <Component {...pageProps} />;
 }
 
 export default wrapper.withRedux(App);

--- a/src/utils/classnames.ts
+++ b/src/utils/classnames.ts
@@ -1,0 +1,3 @@
+const cls = (...classnames: string[]) => classnames.join(' ');
+
+export default cls;

--- a/src/utils/classnames.ts
+++ b/src/utils/classnames.ts
@@ -1,3 +1,3 @@
-const cls = (...classnames: string[]) => classnames.join(' ');
+const classNames = (...classnames: string[]) => classnames.join(' ');
 
-export default cls;
+export default classNames;


### PR DESCRIPTION
## 💬 Issue Number

> closes #9

## 🤷‍♂️ Description

> 작업 내용에 대한 설명
- 헤더와 페이지 컨텐츠가 겹쳐보이는 현상 수정
- 헤더와 바텀바에 컨텐츠가 가려지는 현상 수정

## 📷 Screenshots

> 작업 결과물
<img width="1392" alt="스크린샷 2023-01-18 23 36 42" src="https://user-images.githubusercontent.com/96206089/213201901-4589ea1f-b1c4-4841-951d-637be02d512e.png">
<img width="625" alt="스크린샷 2023-01-18 23 37 25" src="https://user-images.githubusercontent.com/96206089/213201910-4980472f-826c-4858-8754-a01aa54ed0d9.png">

## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

## 📋 Check List

> PR 전 체크해주세요.
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항

페이지 컨텐츠가 헤더랑 바텀바에 가려지고 있어서 상하단에 padding을 추가했습니다.
