### PR TITLE
[fix] 헤더가 정상적으로 나오지 않는 문제 해결

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -10,8 +10,8 @@ const Header = ({ hideOnMobile = false }: HeaderPropsType) => {
   return (
     <div
       className={`${
-        hideOnMobile ? 'md:visible' : 'invisible'
-      } invisible fixed z-50 bg-base-100 navbar border-b border-grey md:shadow-md md:border-none justify-center`}
+        hideOnMobile ? 'md:visible invisible' : 'visible'
+      } fixed z-50 bg-base-100 navbar border-b border-grey md:shadow-md md:border-none justify-center`}
     >
       <div className="max-w-3xl justify-center w-full">
         <div className="navbar-start flex">

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -10,7 +10,7 @@ const Header = ({ hideOnMobile = false }: HeaderPropsType) => {
   return (
     <div
       className={`${
-        hideOnMobile ? 'md:visible invisible' : 'visible'
+        hideOnMobile ? 'md:visible invisible' : ''
       } fixed z-50 bg-base-100 navbar border-b border-grey md:shadow-md md:border-none justify-center`}
     >
       <div className="max-w-3xl justify-center w-full">

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -13,7 +13,7 @@ interface LayoutProps {
 const Layout = ({ children, hideBottomBar, hideHeader, hideHeaderOnMobile }: LayoutProps) => {
   return (
     <>
-      {!hideHeader && <Header />}
+      {!hideHeader && !hideHeaderOnMobile && <Header />}
       {hideHeaderOnMobile && <Header hideOnMobile={true} />}
       <div
         className={classNames(

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -13,8 +13,7 @@ interface LayoutProps {
 const Layout = ({ children, hideBottomBar, hideHeader, hideHeaderOnMobile }: LayoutProps) => {
   return (
     <>
-      {!hideHeader && !hideHeaderOnMobile && <Header />}
-      {hideHeaderOnMobile && <Header hideOnMobile={true} />}
+      {!hideHeader && <Header hideOnMobile={hideHeaderOnMobile} />}
       <div
         className={classNames(
           !hideHeader && !hideBottomBar ? 'py-16' : 'py-0',


### PR DESCRIPTION
## 💬 Issue Number

> closes #20 

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

지난 PR 머지시 충돌이 발생했는데요, 충돌을 해결하는 과정에서 발생한 버그와 기존 개발 시 놓쳤던 부분을 발견해 긴급 수정하였습니다!

- [x] 헤더가 정상적으로 나오도록 헤더 컴포넌트 옵션 수정

## 📷 Screenshots

수정 후 - 기존 페이지에서 헤더가 정상적으로 렌더링됩니다.

<img width="1444" alt="스크린샷 2023-01-29 오후 11 17 05" src="https://user-images.githubusercontent.com/55318618/215332443-863ddbfc-36c8-4d93-b18e-6c5cf1d0f772.png">

## 👻 Good Function

### `Header.tsx`
- `hideOnMobile` 옵션이 true인 경우, 화면 크기가 md보다 작을땐 헤더 invisible, <br /> md 이상일 땐 visible 처리하도록 코드를 수정했습니다.
### `Layout.tsx`
- `hideHeaderOnMobile`을 체크해주는 부분이 빠져있어서, `hideHeaderOnMobile` 옵션이 false일 때도 헤더 컴포넌트를 렌더링하는 문제를 수정했습니다.


## 📋 Check List

> PR 전 체크해주세요.
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
