### PR TITLE
[style] 마켓 목록 페이지 - 최근 거래 휴양지

### DIFF
--- a/src/components/cahoot/DetailInfo.tsx
+++ b/src/components/cahoot/DetailInfo.tsx
@@ -5,7 +5,7 @@ import { useSuspendedQuery } from '@/hooks/useSuspendedQuery';
 import { fetcher } from '@/libs/client/fetcher';
 import type { CahootDetailType } from '@/types/cahoot';
 import type { Response } from '@/types/response';
-import dateFormat from '@/utils/dateFormat';
+import { formatDate } from '@/utils/date';
 
 import Carousel from '../common/Carousel';
 
@@ -63,9 +63,9 @@ const DetailInfo = () => {
           <div className="flex flex-1 flex-col justify-between gap-4 border-grey px-1 text-center">
             공모 기간
             <span className="text-sm font-bold md:text-base">
-              <span>{dateFormat(stockStart ?? '')}</span>
+              <span>{formatDate(stockStart ?? '')}</span>
               <span> ~ </span>
-              <span>{dateFormat(stockEnd ?? '')}</span>
+              <span>{formatDate(stockEnd ?? '')}</span>
             </span>
           </div>
         </div>

--- a/src/components/cahoot/ListItems.tsx
+++ b/src/components/cahoot/ListItems.tsx
@@ -7,7 +7,7 @@ import { fetcher } from '@/libs/client/fetcher';
 import type { CahootListType } from '@/types/cahoot';
 import type { Response } from '@/types/response';
 import classNames from '@/utils/classnames';
-import dateFormat from '@/utils/dateFormat';
+import { formatDate } from '@/utils/date';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 import Icon from '../common/Icons';
@@ -110,7 +110,7 @@ const ListItems = ({ keyword }: ListItemsProps) => {
                     <div className="flex flex-1 items-center justify-center px-1 md:justify-between">
                       <span className="hidden md:block">공모 마감일</span>
                       <span>
-                        {dateFormat(stockEnd)}
+                        {formatDate(stockEnd)}
                         <span className="md:hidden"> 마감</span>
                       </span>
                     </div>

--- a/src/components/cahoot/Recap.tsx
+++ b/src/components/cahoot/Recap.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useSuspendedQuery } from '@/hooks/useSuspendedQuery';
 import type { CahootListType } from '@/types/cahoot';
 import type { Response } from '@/types/response';
-import dateFormat from '@/utils/dateFormat';
+import { formatDate } from '@/utils/date';
 
 import Carousel from '../common/Carousel';
 
@@ -35,7 +35,7 @@ const Recap = () => {
                 {title}
               </span>
               <span className="absolute bottom-0 w-full bg-black/25 text-center text-xs text-white">
-                {dateFormat(stockEnd)}
+                {formatDate(stockEnd)}
               </span>
             </div>
             <div className="flex w-full flex-col gap-1 rounded-b bg-white p-2 text-xs font-normal">

--- a/src/components/market/RecentTrade.tsx
+++ b/src/components/market/RecentTrade.tsx
@@ -1,0 +1,65 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { useSuspendedQuery } from '@/hooks/useSuspendedQuery';
+import { Response } from '@/types/response';
+import { formatTime } from '@/utils/date';
+
+type MockType = {
+  id: number;
+  title: string;
+  price: number;
+  volume: number;
+  images: string[];
+  time: string;
+  diff: number;
+  amount: number;
+}[];
+
+const RecentTrade = () => {
+  const {
+    data: { data: recents },
+  } = useSuspendedQuery<Response<MockType>>(['market/recents'], () =>
+    fetch(`${process.env.NEXT_PUBLIC_HOST}/api/mock/markets/recents`).then((res) => res.json())
+  );
+
+  return (
+    <div className="flex flex-col gap-2 px-3 md:px-0">
+      <label className="font-bold">최근 거래 휴양지</label>
+      <div className="flex flex-col gap-2">
+        {recents.slice(0, 6).map(({ id, amount, diff, images, price, time, title, volume }) => (
+          <Link
+            href={`/markets/detail/${id}`}
+            key={id}
+            className="flex w-full gap-2 even:flex-row-reverse"
+          >
+            <div className="flex flex-col">
+              <div className="avatar -z-10">
+                <div className="w-16 rounded-full border border-grey"></div>
+                <Image src={images[0]} alt="" className="rounded-full" fill sizes="96px" />
+              </div>
+              <span className="text-center text-[10px] text-grey-middle">{formatTime(time)}</span>
+            </div>
+            <div className="flex w-[calc(100%-144px)] flex-col justify-center gap-1 rounded bg-grey px-2 text-xs">
+              <div className="tooltip flex" data-tip={title}>
+                <span className="truncate font-bold">{title}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-black/70">{price.toLocaleString()}</span>
+                <span className={diff < 0 ? 'text-blue' : 'text-red'}>{`${
+                  diff < 0 ? '▼' : '▲'
+                }  ${diff.toLocaleString()}(${Math.round((diff / price) * 100)}%)`}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-black/50">{amount}주</span>
+                <span className="text-black/50">{`${volume.toLocaleString()}(%)`}</span>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RecentTrade;

--- a/src/pages/api/mock/markets/recents.ts
+++ b/src/pages/api/mock/markets/recents.ts
@@ -1,0 +1,30 @@
+import type { Response } from '@/types/response';
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const MOCK = Array(6)
+  .fill(undefined)
+  .map((_, index) => ({
+    id: index + 1,
+    title: '따뜻한 봄바람이 불어오는 하와이 호텔과 게스트하우스',
+    price: 12400,
+    volume: 1235,
+    images: [
+      'https://wealth-marble-image.s3.ap-northeast-2.amazonaws.com/icon-yellow%20flower.png',
+    ],
+    time: '2023-01-20T23:15:53.026633',
+    diff: 1000 * (Math.random() < 0.5 ? 1 : -2),
+    amount: 1,
+  }));
+
+const handler = (req: NextApiRequest, res: NextApiResponse<Response<typeof MOCK>>) => {
+  res.json({ status: 'success', message: null, data: MOCK });
+};
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
+export default handler;

--- a/src/pages/markets/index.tsx
+++ b/src/pages/markets/index.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react';
 import DeadlineBanner from '@/components/cahoot/DeadlineBanner';
 import Layout from '@/components/common/Layout';
 import Interests from '@/components/market/Interests';
+import RecentTrade from '@/components/market/RecentTrade';
 import { ErrorBoundary } from '@sentry/nextjs';
 
 import type { GetServerSideProps } from 'next';
@@ -25,6 +26,16 @@ const Markets = () => {
           <Suspense fallback={<p>로딩...</p>}>
             <Interests />
           </Suspense>
+          <div className="flex flex-col-reverse gap-4 md:flex-row">
+            <div className="md:w-1/2">
+              <label className="font-bold">가격 정보</label>
+            </div>
+            <div className="md:w-1/2">
+              <Suspense fallback={<p>로딩...</p>}>
+                <RecentTrade />
+              </Suspense>
+            </div>
+          </div>
         </ErrorBoundary>
       </div>
     </Layout>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -3,3 +3,10 @@ export const formatDate = (date: string) =>
     .format(new Date(date || 0))
     .replace(/\s|\.$/g, '');
 
+export const formatTime = (date: string) =>
+  Intl.DateTimeFormat('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(new Date(date || 0));

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,6 +1,5 @@
-const dateFormat = (date: string) =>
+export const formatDate = (date: string) =>
   Intl.DateTimeFormat('ko-KR', { dateStyle: 'short' })
     .format(new Date(date || 0))
     .replace(/\s|\.$/g, '');
 
-export default dateFormat;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,7 +29,11 @@ module.exports = {
       'blue-start': '#00628B',
       'blue-end': '#017797',
     },
-    extend: {},
+    extend: {
+      padding: {
+        18: '4.5rem',
+      },
+    },
   },
   daisyui: {
     themes: [


### PR DESCRIPTION
## 💬 Issue Number

> closes #41 

## 🤷‍♂️ Description

> 작업 내용에 대한 설명
- 최근 거래 휴양지 구현
- 최근 거래 휴양지 mock api 작성

## 📷 Screenshots

> 작업 결과물
<img width="965" alt="Screenshot 2023-02-17 at 18 24 20" src="https://user-images.githubusercontent.com/96206089/219605646-72ac9b5c-dc0b-4762-83fc-5f12c1e52ee1.png">

<img width="390" alt="Screenshot 2023-02-17 at 18 24 20" src="https://user-images.githubusercontent.com/96206089/219605675-8e69a066-6401-4c6b-92c3-a9120a9ac4d6.png">

## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

daisyUI의 tooltip 기능을 사용해서 휴양지 이름에 hover 시 전체 휴양지 이름이 나오도록 구현했습니다.

## 📋 Check List

> PR 전 체크해주세요.
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항

거래량 %가 어떤 기준에서 계산하는지 정확히 모르겠어서 해당 부분은 비워놨습니다.