### PR TITLE
[style] 장소별 추천 휴양지 필터링 UI 구현

### DIFF
--- a/src/components/RecommendedList.tsx
+++ b/src/components/RecommendedList.tsx
@@ -1,7 +1,8 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 import Link from 'next/link';
 
+import ButtonGroup from '@/components/common/ButtonGroup';
 import SelectBox from '@/components/common/SelectBox';
 import classNames from '@/utils/classnames';
 import { useQuery } from '@tanstack/react-query';
@@ -19,8 +20,11 @@ interface MockDataType {
   bookmarked: boolean;
 }
 
+const RecommendedCountryList = ['대만', '일본', '파푸아뉴기니'] as const;
+
 const RecommendedList = () => {
   const selectBoxContainer = useRef<HTMLDivElement>(null);
+  const [selectedCountry, setSelectedCountry] = useState('장소');
   const { data } = useQuery<MockDataType[]>({
     queryKey: ['cahootListData'],
     queryFn: () =>
@@ -31,47 +35,70 @@ const RecommendedList = () => {
     e.preventDefault();
   };
 
+  // SelectBox, ButtonGroup을 통해 나라 변경 시 동작
+  const changeCountry = (country: string) => {
+    setSelectedCountry(country);
+    // console.log(country);
+  };
+
+  const selectItems = [
+    { index: 1, item: '대만' },
+    { index: 2, item: '일본' },
+    { index: 3, item: '파푸아뉴기니' },
+    { index: 4, item: '미국' },
+  ];
+
   return (
     <div
       ref={selectBoxContainer}
-      className="relative flex flex-col px-4 md:px-0 py-4 gap-4 md:w-96"
+      className="relative flex flex-col gap-4 px-4 py-4 md:w-96 md:px-0"
     >
-      <div className="flex justify-between items-center">
+      <div className="flex items-center justify-between">
         <label className="font-bold">장소별 추천 휴양지</label>
       </div>
-      <div>
-        <SelectBox placeholder="장소" containerRef={selectBoxContainer} />
+      <div className="flex gap-4">
+        <SelectBox
+          items={selectItems}
+          containerRef={selectBoxContainer}
+          currentItem={selectedCountry}
+          changeItem={changeCountry}
+        />
+        <ButtonGroup
+          items={RecommendedCountryList}
+          currentItem={selectedCountry}
+          changeItem={changeCountry}
+        />
       </div>
-      <div className="w-full grid grid-cols-6 md:grid-cols-3 gap-2 gap-y-6 max-md:carousel ">
+      <div className="grid w-full grid-cols-6 gap-2 gap-y-6 max-md:carousel md:grid-cols-3 ">
         {data?.map(({ id, bookmarked, title }) => (
           <Link
             href={`/cahoots/detail/${id}`}
             key={id}
-            className="rounded border border-grey shadow-md flex flex-col gap-1 w-32"
+            className="flex w-32 flex-col gap-1 rounded border border-grey shadow-md"
           >
             {/* 이미지 */}
             <div className="avatar">
-              <div className="w-full bg-dark-grey rounded-t"></div>
+              <div className="w-full rounded-t bg-dark-grey"></div>
               <div className="absolute right-2 top-2">
                 <button
                   onClick={onBookmarkClick}
                   className={classNames(
-                    'btn btn-circle btn-ghost btn-xs',
-                    bookmarked ? 'text-main fill-main' : 'fill-none'
+                    'btn btn-ghost btn-xs btn-circle',
+                    bookmarked ? 'fill-main text-main' : 'fill-none'
                   )}
                 >
                   <Icon.Bookmark />
                 </button>
               </div>
             </div>
-            <div className="flex flex-col w-full overflow-hidden py-1 relative justify-center px-2 text-[8px]">
-              <div className="font-bold flex gap-2">
-                <span className="bg-main text-white px-1 rounded">Hot</span>
-                <span className="overflow-ellipsis overflow-hidden whitespace-nowrap">{title}</span>
+            <div className="relative flex w-full flex-col justify-center overflow-hidden py-1 px-2 text-[8px]">
+              <div className="flex gap-2 font-bold">
+                <span className="rounded bg-main px-1 text-white">Hot</span>
+                <span className="overflow-hidden overflow-ellipsis whitespace-nowrap">{title}</span>
               </div>
-              <div className="flex gap-1 gap-4 flex-col"></div>
+              <div className="flex flex-col gap-1 gap-4"></div>
               <div className="text-right">
-                <span className="text-black/60 text-[6px]">
+                <span className="text-[6px] text-black/60">
                   예상 수익률 <span className="text-main">120%</span>
                 </span>
               </div>

--- a/src/components/common/ButtonGroup.tsx
+++ b/src/components/common/ButtonGroup.tsx
@@ -1,0 +1,34 @@
+import classNames from '@/utils/classnames';
+
+interface PropsType {
+  items: readonly string[];
+  currentItem: string;
+  changeItem: (item: string) => void;
+}
+
+const ButtonGroup = ({ items, currentItem, changeItem }: PropsType) => {
+  const onClickButton = (item: string) => {
+    changeItem(item);
+  };
+
+  return (
+    <div className="flex h-6 gap-2">
+      {items.map((item, index) => (
+        <button
+          key={index}
+          className={classNames(
+            'w-12 truncate rounded-lg px-1 text-[10px]',
+            currentItem === item
+              ? 'bg-main text-white'
+              : 'btn-secondary border border-grey bg-white font-medium text-black/60'
+          )}
+          onClick={() => onClickButton(item)}
+        >
+          {item}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default ButtonGroup;

--- a/src/components/common/ButtonGroup.tsx
+++ b/src/components/common/ButtonGroup.tsx
@@ -12,10 +12,11 @@ const ButtonGroup = ({ items, currentItem, changeItem }: PropsType) => {
   };
 
   return (
-    <div className="flex h-6 gap-2">
+    <div className="flex h-6 gap-1.5">
       {items.map((item, index) => (
         <button
           key={index}
+          title={item}
           className={classNames(
             'w-12 truncate rounded-lg px-1 text-[10px]',
             currentItem === item

--- a/src/components/common/Icons.tsx
+++ b/src/components/common/Icons.tsx
@@ -138,7 +138,7 @@ const Up = () => (
     viewBox="0 0 24 24"
     strokeWidth={1.5}
     stroke="currentColor"
-    className="w-6 h-6"
+    className="h-4 w-4"
   >
     <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
   </svg>
@@ -151,7 +151,7 @@ const Down = () => (
     viewBox="0 0 24 24"
     strokeWidth={1.5}
     stroke="currentColor"
-    className="w-6 h-6"
+    className="h-3 w-3"
   >
     <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
   </svg>

--- a/src/components/common/Icons.tsx
+++ b/src/components/common/Icons.tsx
@@ -138,7 +138,7 @@ const Up = () => (
     viewBox="0 0 24 24"
     strokeWidth={1.5}
     stroke="currentColor"
-    className="h-4 w-4"
+    className="h-3 w-3"
   >
     <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
   </svg>

--- a/src/components/common/SelectBox.tsx
+++ b/src/components/common/SelectBox.tsx
@@ -3,28 +3,31 @@ import { createPortal } from 'react-dom';
 
 import Icon from './Icons';
 
-interface PropsType {
-  placeholder: string;
-  containerRef: React.RefObject<HTMLDivElement>;
+interface SelectItem {
+  index: number;
+  item: string;
 }
-const SelectBox = ({ placeholder, containerRef }: PropsType) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const [selectedValue, setSelectedValue] = useState(placeholder);
 
-  const handleClick = (e: MouseEvent) => {
+interface PropsType {
+  items: SelectItem[];
+  containerRef: React.RefObject<HTMLDivElement>;
+  currentItem: string;
+  changeItem: (item: string) => void;
+}
+const SelectBox = ({ items, containerRef, currentItem, changeItem }: PropsType) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onClickToggle = (e: MouseEvent) => {
     e.stopPropagation();
     setIsOpen(!isOpen);
   };
 
-  const selectValue = (e: MouseEvent) => {
-    const eventTarget = e.target as HTMLElement;
-
-    console.log('click value');
+  const onClickItem = (item: string) => {
     setIsOpen(false);
-    setSelectedValue(eventTarget.innerText);
+    changeItem(item);
   };
 
-  const handleBlur = () => {
+  const onBlur = () => {
     setTimeout(() => {
       setIsOpen(false);
     }, 100);
@@ -33,12 +36,12 @@ const SelectBox = ({ placeholder, containerRef }: PropsType) => {
   return (
     <div className="w-24">
       <div
-        onBlur={handleBlur}
+        onBlur={onBlur}
         tabIndex={4}
-        onClick={handleClick}
-        className="flex justify-between border border-grey w-24 rounded-lg px-3 py-2"
+        onClick={onClickToggle}
+        className="flex w-24 justify-between rounded-lg border border-grey px-3 py-2"
       >
-        <span>{selectedValue}</span>
+        <span>{currentItem}</span>
         <span>
           {isOpen && <Icon.Up></Icon.Up>}
           {!isOpen && <Icon.Down></Icon.Down>}
@@ -52,18 +55,16 @@ const SelectBox = ({ placeholder, containerRef }: PropsType) => {
             } absolute top-20 mt-6 w-24 rounded-lg border border-grey bg-white`}
           >
             <ul className="list-inside list-none ">
-              <li
-                onClick={selectValue}
-                className="cursor-pointer select-none rounded-lg p-2 hover:bg-main/50"
-              >
-                대만
-              </li>
-              <li
-                onClick={selectValue}
-                className="cursor-pointer select-none rounded-lg p-2 hover:bg-main/50"
-              >
-                일본
-              </li>
+              {items.map(({ index, item }) => (
+                // TODO: 말줄임표 추가하기
+                <li
+                  key={index.toString()}
+                  onClick={() => onClickItem(item)}
+                  className="cursor-pointer select-none rounded-lg p-2 hover:bg-main/50"
+                >
+                  {item}
+                </li>
+              ))}
             </ul>
           </div>,
           containerRef.current

--- a/src/components/common/SelectBox.tsx
+++ b/src/components/common/SelectBox.tsx
@@ -58,6 +58,7 @@ const SelectBox = ({ items, containerRef, currentItem, changeItem }: PropsType) 
               {items.map(({ index, item }) => (
                 <li
                   key={index.toString()}
+                  title={item}
                   onClick={() => onClickItem(item)}
                   className="cursor-pointer select-none truncate rounded-lg p-2 text-[10px] hover:bg-main/50"
                 >

--- a/src/components/common/SelectBox.tsx
+++ b/src/components/common/SelectBox.tsx
@@ -34,14 +34,14 @@ const SelectBox = ({ items, containerRef, currentItem, changeItem }: PropsType) 
   };
 
   return (
-    <div className="w-24">
+    <div>
       <div
         onBlur={onBlur}
         tabIndex={4}
         onClick={onClickToggle}
-        className="flex w-24 justify-between rounded-lg border border-grey px-3 py-2"
+        className="flex	h-6 w-16 items-center justify-between rounded-lg border border-grey px-3 "
       >
-        <span>{currentItem}</span>
+        <span className="truncate text-[10px]">{currentItem}</span>
         <span>
           {isOpen && <Icon.Up></Icon.Up>}
           {!isOpen && <Icon.Down></Icon.Down>}
@@ -52,15 +52,14 @@ const SelectBox = ({ items, containerRef, currentItem, changeItem }: PropsType) 
           <div
             className={`${
               isOpen ? 'visible' : 'invisible'
-            } absolute top-20 mt-6 w-24 rounded-lg border border-grey bg-white`}
+            } absolute top-20 mt-2 w-24 rounded-lg border border-grey bg-white`}
           >
             <ul className="list-inside list-none ">
               {items.map(({ index, item }) => (
-                // TODO: 말줄임표 추가하기
                 <li
                   key={index.toString()}
                   onClick={() => onClickItem(item)}
-                  className="cursor-pointer select-none rounded-lg p-2 hover:bg-main/50"
+                  className="cursor-pointer select-none truncate rounded-lg p-2 text-[10px] hover:bg-main/50"
                 >
                   {item}
                 </li>


### PR DESCRIPTION
## 💬 Issue Number

> closes #30 

## 🤷‍♂️ Description

> 작업 내용에 대한 설명
- [x] 메인페이지의 장소별 추천 휴양지 UI 구현

## 📷 Screenshots

> 작업 결과물
<img width="450" alt="스크린샷 2023-02-17 오후 11 40 36" src="https://user-images.githubusercontent.com/55318618/219684974-8c88c78a-6651-4ac4-b366-73224416b32b.png">


## 📋 Check List

> PR 전 체크해주세요.
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항

data fetching 코드는 추후 API 연동 시 작성하려고 일단 컴포넌트 안에 임시 데이터로 넣어두었습니다.
